### PR TITLE
Update Buildings.json

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -78,7 +78,7 @@
 		"hurryCostModifier": 25,
 		"maintenance": 2,
 		"uniques": [
-			"Must have an owned [Lake] within [2] tiles",
+			"Must have an owned [Water pump] within [3] tiles",
 			"[+1] food from [Farm] tiles [in this city]"
 		],
 		"requiredTech": "Botany"


### PR DESCRIPTION
The original file has the unique ''Must have an owned [tileFilter] within [amount] tiles'' for the Irrigation building, and has 'Lakes' as the needed tile. However, [tileFilter] requires an improvement, not a terrain, to function properly. Lakes being rather rare on most maps, it makes sense to require a Water pump instead, and this fits the [tileFilter] nicely.